### PR TITLE
Fix potentials WorldGuard issues.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,10 @@
             <id>sonatype</id>
             <url>https://oss.sonatype.org/content/groups/public/</url>
         </repository>
+        <repository>
+            <id>sk89q-repo</id>
+            <url>https://maven.enginehub.org/repo/</url>
+        </repository>
     </repositories>
 
     <dependencies>
@@ -68,6 +72,12 @@
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
             <version>1.19.3-R0.1-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.sk89q.worldguard</groupId>
+            <artifactId>worldguard-bukkit</artifactId>
+            <version>7.0.8</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/com/segoitch/easyapples/EasyApples.java
+++ b/src/main/java/com/segoitch/easyapples/EasyApples.java
@@ -6,20 +6,32 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Random;
 
+import com.sk89q.worldedit.bukkit.BukkitAdapter;
+import com.sk89q.worldedit.util.Location;
+import com.sk89q.worldguard.LocalPlayer;
+import com.sk89q.worldguard.WorldGuard;
+import com.sk89q.worldguard.bukkit.WorldGuardPlugin;
+import com.sk89q.worldguard.protection.flags.Flags;
+import com.sk89q.worldguard.protection.regions.RegionContainer;
+import com.sk89q.worldguard.protection.regions.RegionQuery;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.Sound;
+import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.Action;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.java.JavaPlugin;
 
 public class EasyApples extends JavaPlugin implements Listener {
 
+    private boolean isWorldGuardExist;
     private ItemStack apple;
     private ItemStack stick;
     private double appleProcChance;
@@ -30,9 +42,9 @@ public class EasyApples extends JavaPlugin implements Listener {
 
     @Override
     public void onEnable() {
-        Random random = new Random();
+        this.isWorldGuardExist = this.isWorldGuardExist();
         this.apple = new ItemStack(Material.APPLE, 1);
-        this.stick = new ItemStack(Material.STICK, random.nextInt(1, 2));
+        this.stick = new ItemStack(Material.STICK, 1);
         this.appleProcChance = 0.05;
         this.stickProcChance = 0.20;
         this.playerTries = new HashMap<>();
@@ -45,14 +57,18 @@ public class EasyApples extends JavaPlugin implements Listener {
         Bukkit.getPluginManager().registerEvents(this, this);
     }
 
-    @EventHandler
-    public void onLeavesRightClick(PlayerInteractEvent event) {
+    @EventHandler (ignoreCancelled = true, priority = EventPriority.NORMAL)
+    public void onPlayerInteract(PlayerInteractEvent event) {
         final Player player = event.getPlayer();
         // Check to fire event only one time (because basically it fires once for each hand)
         if (event.getHand() != EquipmentSlot.HAND || event.getAction() == Action.LEFT_CLICK_BLOCK
                 || event.getAction() != Action.RIGHT_CLICK_BLOCK || event.getClickedBlock() == null) return;
         if (!leavesList.contains(event.getClickedBlock().getType())) return;
         if(event.getPlayer().getInventory().getItemInMainHand().getType() != Material.AIR) return;
+
+        final Block block = event.getClickedBlock();
+        if(this.wgCancelled(player, block)) return;
+
         if (!playerTries.containsKey(player)) playerTries.put(player, 0);
 
         player.playSound(event.getClickedBlock().getLocation(), Sound.BLOCK_AZALEA_LEAVES_HIT, 0.10F, 1.0F);
@@ -65,17 +81,38 @@ public class EasyApples extends JavaPlugin implements Listener {
             event.getClickedBlock().breakNaturally(); // to get saplings too
             player.playSound(event.getClickedBlock().getLocation(), Sound.BLOCK_AZALEA_LEAVES_BREAK, 0.33F, 1.0F);
             this.playerTries.replace(player, 0);
-            player.getInventory().addItem(this.stick);
 
-            if (Math.random() <= this.appleProcChance) {
-                player.getInventory().addItem(this.apple);
-            }
-            return;
+            ItemStack randomStick = this.stick;
+            randomStick.setAmount(new Random().nextInt(1, 2));
+
+            player.getInventory().addItem(randomStick);
+
+            if (Math.random() <= this.appleProcChance) player.getInventory().addItem(this.apple);
         }
         if (this.playerTries.get(player) >= this.maxTries) { // chance failed, nothing gained
             event.getClickedBlock().breakNaturally(); // to get saplings too
             player.playSound(event.getClickedBlock().getLocation(), Sound.BLOCK_AZALEA_LEAVES_BREAK, 0.33F, 1.0F);
             this.playerTries.replace(player, 0);
         }
+    }
+
+    private boolean isWorldGuardExist() {
+        Plugin plugin = getServer().getPluginManager().getPlugin("WorldGuard");
+        return plugin instanceof WorldGuardPlugin;
+    }
+
+    private boolean wgCancelled(final Player player, final Block block) {
+        if(block == null || !this.isWorldGuardExist) return false;
+        boolean result = false;
+
+        final LocalPlayer localPlayer = WorldGuardPlugin.inst().wrapPlayer(player);
+        final Location loc = BukkitAdapter.adapt(block.getLocation());
+        final RegionContainer container = WorldGuard.getInstance().getPlatform().getRegionContainer();
+        final RegionQuery query = container.createQuery();
+
+        if (!query.testState(loc, localPlayer, Flags.LEAF_DECAY)) result = true;
+        if (!query.testState(loc, localPlayer, Flags.BLOCK_BREAK)) result = true;
+
+        return result;
     }
 }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -2,3 +2,4 @@ name: EasyApples
 version: '${project.version}'
 main: com.segoitch.easyapples.EasyApples
 api-version: 1.19
+softdepend: [WorldGuard]


### PR DESCRIPTION
### This pull request...
  - [X] Fixes a bug
  - [X] Introduces a new feature
  - [X] Improves an existing feature

### Description
This PR corrects a problem reported in issue [#4] (https://github.com/SegoItCh/EasyApples/issues/4). 👋🏻 @AdamDAuria

### Purpose
Addition of a function to check whether WorldGuard is active on the server and, in this case, to check whether certain protection flags are not active in order to prevent players from interacting with the leaves if the zone does not initially allow them to do so.

### Notice
I haven't tested the added features. They should work, but a real-life test is absolutely necessary.
